### PR TITLE
Highlight high ride summary metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,32 @@ Provides aggregate statistics for the requested period. Fields may include total
 ]
 ```
 
+### `GET /api/activity/{id}/summary`
+Returns a summary of a single ride. A `trend` object compares each metric to the rider's past 90 days. Each value is one of `very_low`, `low`, `normal`, `high` or `very_high` based on standard deviation bands:
+
+* `very_high` >= mean + 1.5*stdev
+* `high` >= mean + 0.5*stdev
+* `normal` within ±0.5*stdev
+* `low` <= mean - 0.5*stdev
+* `very_low` <= mean - 1.5*stdev
+
+```json
+{
+  "distance": 40500,
+  "elevation_gain": 520,
+  "moving_time": 4300,
+  "average_speed": 8.5,
+  "max_speed": 16.2,
+  "training_stress_score": 160,
+  "intensity_factor": 0.92,
+  "normalized_power": 310,
+  "trend": {
+    "avg_speed": "very_high",
+    "max_speed": "normal",
+    "tss": "high",
+    "intensity": "high",
+    "power": "high"
+  }
+}
+```
+

--- a/src/components/RecentRides.jsx
+++ b/src/components/RecentRides.jsx
@@ -6,6 +6,18 @@ import MapThumbnail from './MapThumbnail';
 const metersToKm = (m) => m / 1000;
 const metersToFeet = (m) => m * 3.28084;
 
+// Ride summaries include a `trend` object describing how each metric
+// compares to the rider's recent history. Values are strings such as
+// 'very_high', 'high', 'normal', 'low' and 'very_low' calculated using
+// the past 90 days of data. Older boolean `highlight` fields are still
+// handled for backward compatibility.
+
+const statusClass = (val) => {
+  if (val === true || val === 'high' || val === 'very_high') return 'metric-high';
+  if (val === 'low' || val === 'very_low') return 'metric-low';
+  return '';
+};
+
 // Polyline decoding (returns array of [lat, lng])
 const decodePolyline = (str) => {
   let index = 0,
@@ -171,6 +183,7 @@ const RecentRides = ({ count = 10 }) => {
         const tss = rideData.training_stress_score ?? rideData.tss;
         const ifVal = rideData.intensity_factor ?? rideData.intensity;
         const weightedPower = rideData.normalized_power ?? rideData.weighted_average_power ?? rideData.weighted_average_watts;
+        const trend = rideData.trend ?? rideData.highlight ?? rideData.high ?? {};
         const desc = rideData.description ?? rideData.summary ?? '';
         const dateStr = (() => {
           const dateRaw = rideData.date ?? rideData.start_date ?? rideData.startTime ?? rideData.timestamp;
@@ -201,11 +214,31 @@ const RecentRides = ({ count = 10 }) => {
               </div>
               <div className="ride-metrics">
                 {movingTimeStr && <span>Time {movingTimeStr}</span>}
-                {avgSpeedKph && <span>AvgSpd {avgSpeedKph.toFixed(1)} km/h</span>}
-                {maxSpeedKph && <span>Max {maxSpeedKph.toFixed(1)} km/h</span>}
-                {tss && <span>TSS {tss.toFixed?.(0) ?? tss}</span>}
-                {ifVal && <span>Int {ifVal.toFixed?.(2) ?? ifVal}</span>}
-                {weightedPower && <span>Pow {weightedPower} W</span>}
+                {avgSpeedKph && (
+                  <span className={statusClass(trend.avg_speed)}>
+                    AvgSpd {avgSpeedKph.toFixed(1)} km/h
+                  </span>
+                )}
+                {maxSpeedKph && (
+                  <span className={statusClass(trend.max_speed)}>
+                    Max {maxSpeedKph.toFixed(1)} km/h
+                  </span>
+                )}
+                {tss && (
+                  <span className={statusClass(trend.tss)}>
+                    TSS {tss.toFixed?.(0) ?? tss}
+                  </span>
+                )}
+                {ifVal && (
+                  <span className={statusClass(trend.intensity)}>
+                    Int {ifVal.toFixed?.(2) ?? ifVal}
+                  </span>
+                )}
+                {weightedPower && (
+                  <span className={statusClass(trend.power)}>
+                    Pow {weightedPower} W
+                  </span>
+                )}
               </div>
               {desc && <p className="ride-desc">{desc}</p>}
               {dateStr && <div className="ride-date">{dateStr}</div>}

--- a/src/styles.css
+++ b/src/styles.css
@@ -398,6 +398,16 @@ body {
   opacity: 0.9;
 }
 
+.metric-high {
+  color: #ffdc50;
+  font-weight: 600;
+}
+
+.metric-low {
+  color: #90cdf4;
+  font-weight: 600;
+}
+
 .ride-map-container {
   position: relative;
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- mark metrics using trend-based classification rather than booleans
- document `/api/activity/{id}/summary` trend object and algorithm
- show high/low metrics using `metric-high` and `metric-low` classes

## Testing
- `yarn test --run`


------
https://chatgpt.com/codex/tasks/task_e_686a951c0cf08320bf151d9cc5650a3a