### PR TITLE
Display ride elevation in meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Provides aggregate statistics for the requested period. Fields may include total
 ```
 
 ### `GET /api/activity/{id}/summary`
-Returns a summary of a single ride. A `trend` object compares each metric to the rider's past 90 days. Each value is one of `very_low`, `low`, `normal`, `high` or `very_high` based on standard deviation bands:
+Returns a summary of a single ride. A `trend` object compares each metric to the rider's past 90 days. Elevation gain is provided in **meters**. Each value is one of `very_low`, `low`, `normal`, `high` or `very_high` based on standard deviation bands:
 
 * `very_high` >= mean + 1.5*stdev
 * `high` >= mean + 0.5*stdev
@@ -117,7 +117,7 @@ Returns a summary of a single ride. A `trend` object compares each metric to the
 ```json
 {
   "distance": 40500,
-  "elevation_gain": 520,
+  "total_elevation_gain": 520,
   "moving_time": 4300,
   "average_speed": 8.5,
   "max_speed": 16.2,

--- a/src/components/RecentRides.jsx
+++ b/src/components/RecentRides.jsx
@@ -4,7 +4,6 @@ import MapThumbnail from './MapThumbnail';
 
 // Helper conversions
 const metersToKm = (m) => m / 1000;
-const metersToFeet = (m) => m * 3.28084;
 
 // Ride summaries include a `trend` object describing how each metric
 // compares to the rider's recent history. Values are strings such as
@@ -175,7 +174,7 @@ const RecentRides = ({ count = 10 }) => {
 
         const name = rideData.name ?? 'Ride';
         const distanceKm = metersToKm(rideData.distance ?? rideData.total_distance ?? 0);
-        const elevFt = metersToFeet(rideData.total_elevation_gain ?? rideData.elevation_gain ?? 0);
+        const elevM = rideData.total_elevation_gain ?? rideData.elevation_gain ?? 0;
         const moveSec = rideData.duration ?? rideData.moving_time ?? rideData.movingTime ?? rideData.elapsed_time ?? 0;
         const movingTimeStr = moveSec
           ? new Date(moveSec * 1000).toISOString().substring(11, 19)
@@ -213,7 +212,7 @@ const RecentRides = ({ count = 10 }) => {
             <div className="ride-info">
               <div className="ride-title">{name}</div>
               <div className="ride-stats">
-                {distanceKm.toFixed(1)} km · {elevFt.toFixed(0)} ft
+                {distanceKm.toFixed(1)} km · {elevM.toFixed(0)} m
               </div>
               <div className="ride-metrics">
                 {movingTimeStr && (
@@ -263,7 +262,7 @@ const RecentRides = ({ count = 10 }) => {
               {desc && <p className="ride-desc">{desc}</p>}
               {dateStr && <div className="ride-date">{dateStr}</div>}
             </div>
-            <div className="ride-elevation">{elevFt.toFixed(0)} ft</div>
+            <div className="ride-elevation">{elevM.toFixed(0)} m</div>
             {coords && <MapThumbnail coords={coords} />}
           </div>
         );


### PR DESCRIPTION
## Summary
- use the elevation value from ride summaries
- show total elevation gain in meters instead of feet
- document new `total_elevation_gain` field in the API example

## Testing
- `yarn test --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad07cab348320ac487dbdd3195e55